### PR TITLE
Rename methods on Logger

### DIFF
--- a/Autoloads/Logger.gd
+++ b/Autoloads/Logger.gd
@@ -1,40 +1,48 @@
 extends Node
 
 
+# Log headers
 const DEBUG_TAG = "[DEBUG]"
 const INFOR_TAG	= "[INFOR]"
 const ERROR_TAG = "[ERROR]"
 const SEPARATOR = " "
 
 
+# Log levels allowed
 enum {DEBUG_LEVEL, INFOR_LEVEL, ERROR_LEVEL}
 
 
-var logLevel
+# Current log level
+var m_logLevel
 
 
 # Use of _init() in place of _ready() because the first is executed before
 # This is needed because other autoloads use this node and it's not ready yet
 func _init():
-	self.logLevel = DEBUG_LEVEL
+	m_logLevel = DEBUG_LEVEL
 
 
+# Log level setter
 func setLogLevel(logLevel : int):
-	self.logLevel = logLevel
+	m_logLevel = logLevel
 
 
-func log(tag : String, message : String, logLevel : int):
-	if logLevel >= self.logLevel:
+# Method in charge of printing a message into the stdout
+func logMessage(tag : String, message : String, logLevel : int):
+	if logLevel >= m_logLevel:
 		print(tag, SEPARATOR, message)
 
 
+# Wrapper for logMessage() with DEBUG level
 func logDebug(message : String):
-	self.log(DEBUG_TAG, message, DEBUG_LEVEL)
+	logMessage(DEBUG_TAG, message, DEBUG_LEVEL)
 
 
-func logInfo(message : String):
-	self.log(INFOR_TAG, message, INFOR_LEVEL)
+# Wrapper for logMessage() with INFOR level
+func logInfor(message : String):
+	logMessage(INFOR_TAG, message, INFOR_LEVEL)
 
 
+# Wrapper for logMessage() with ERROR level
 func logError(message : String):
-	self.log(ERROR_TAG, message, ERROR_LEVEL)
+	logMessage(ERROR_TAG, message, ERROR_LEVEL)

--- a/Autoloads/Logger.gd
+++ b/Autoloads/Logger.gd
@@ -28,21 +28,21 @@ func setLogLevel(logLevel : int):
 
 
 # Method in charge of printing a message into the stdout
-func logMessage(tag : String, message : String, logLevel : int):
+func _log(tag : String, message : String, logLevel : int):
 	if logLevel >= m_logLevel:
 		print(tag, SEPARATOR, message)
 
 
-# Wrapper for logMessage() with DEBUG level
+# Wrapper for _log() with DEBUG level
 func logDebug(message : String):
-	logMessage(DEBUG_TAG, message, DEBUG_LEVEL)
+	_log(DEBUG_TAG, message, DEBUG_LEVEL)
 
 
-# Wrapper for logMessage() with INFOR level
+# Wrapper for _log() with INFOR level
 func logInfor(message : String):
-	logMessage(INFOR_TAG, message, INFOR_LEVEL)
+	_log(INFOR_TAG, message, INFOR_LEVEL)
 
 
-# Wrapper for logMessage() with ERROR level
+# Wrapper for _log() with ERROR level
 func logError(message : String):
-	logMessage(ERROR_TAG, message, ERROR_LEVEL)
+	_log(ERROR_TAG, message, ERROR_LEVEL)

--- a/Game/Game.gd
+++ b/Game/Game.gd
@@ -12,7 +12,7 @@ signal Exit
 
 
 func _ready()->void:
-	Logger.logInfo("Starting game")
+	Logger.logInfor("Starting game")
 	
 	connect("Exit", self.on_exit)
 	connect("ChangeScene", self.on_changeScene)
@@ -44,6 +44,6 @@ func on_changeScene(newScene, transitionType)->void:
 
 
 func on_exit()->void:
-	Logger.logInfo("Exiting game")
+	Logger.logInfor("Exiting game")
 	
 	get_tree().quit()


### PR DESCRIPTION
| Issue |
| - |
| Closes #26 |

Rename some logger stuff in order to solve editor's warning.