### PR TITLE
Refactor `GameSettings` autoload to commit changes just once

### DIFF
--- a/Template/Autoloads/GameSettings.gd
+++ b/Template/Autoloads/GameSettings.gd
@@ -56,25 +56,25 @@ func save_config_file(config_file: ConfigFile) -> int:
 
 
 # Get config value, given a section and a key.
-func get_setting(section: String, key: String):
+func get_setting(section: String, key: String) -> Variant:
 	var section_settings = get_section_settings(section)
 	if section_settings != null:
 		if section_settings.has(key):
 			return section_settings.get(key)
 		print_debug(str("No such key: ", key))
-		return null
-
-
-# Get section configs.
-func get_section_settings(section: String):
-	if m_config_map.has(section):
-		return m_config_map.get(section)
-	print_debug(str("No such section: ", section))
 	return null
 
 
+# Get section configs.
+func get_section_settings(section: String) -> Dictionary:
+	if m_config_map.has(section):
+		return m_config_map.get(section)
+	print_debug(str("No such section: ", section))
+	return Dictionary()
+
+
 # Set setting, given a section, a key, and a new value.
-func set_setting(section: String, key: String, value: Variant):
+func set_setting(section: String, key: String, value: Variant) -> void:
 	m_config_map[section][key] = value
 
 

--- a/Template/Autoloads/GameSettings.gd
+++ b/Template/Autoloads/GameSettings.gd
@@ -55,17 +55,18 @@ func save_config_file(config_file: ConfigFile) -> int:
 	return OK
 
 
-# Get config value, given a section and a key.
+# Get config value, given a section and a key. If config is not found, returns
+# null.
 func get_setting(section: String, key: String) -> Variant:
 	var section_settings = get_section_settings(section)
-	if section_settings != null:
+	if not section_settings.is_empty():
 		if section_settings.has(key):
 			return section_settings.get(key)
 		print_debug(str("No such key: ", key))
 	return null
 
 
-# Get section configs.
+# Get section configs. If section is not found, returns an empty dictionary.
 func get_section_settings(section: String) -> Dictionary:
 	if m_config_map.has(section):
 		return m_config_map.get(section)

--- a/Template/Autoloads/GameSettings.gd
+++ b/Template/Autoloads/GameSettings.gd
@@ -5,87 +5,81 @@ enum DIFFICULTY { EASY, NORMAL, HARD }
 
 const CONFIG_FILE_PATH = "res://config.cfg"
 
-var m_config
-var m_game_difficulty
-var m_music_volume
-var m_sfx_volume
+var m_config_map
 
 
-# Use of _init() in place of _ready() because the first is executed before
-# This is needed because other autoloads use this node and it's not ready yet
+# Load setting from the config file.
+# _init() is needed in place of _ready() because other nodes need this autload.
 func _init():
-	m_config = ConfigFile.new()
-	var err = m_config.load(CONFIG_FILE_PATH)
+	print("Loading configs from filesystem")
+	load_settings_from_filesystem()
+
+
+# Load configs from the config file and store them in memory. This is intended
+# to be called just at the beginning of the execution.
+func load_settings_from_filesystem() -> void:
+	var config_file = load_config_file()
+	m_config_map = Dictionary()
+	for section in config_file.get_sections():
+		m_config_map[section] = Dictionary()
+		for key in config_file.get_section_keys(section):
+			m_config_map[section][key] = config_file.get_value(section, key)
+
+
+# Read config file.
+func load_config_file() -> ConfigFile:
+	var config = ConfigFile.new()
+	var err = config.load(CONFIG_FILE_PATH)
 	if err != OK:
 		print_debug(str("Error (", err, ") loading config file."))
-	else:
-		get_difficulty_from_filesystem()
-		get_volumes_from_filesystem()
+		return null
+	return config
 
 
-func get_setting(section, key):
-	if m_config.has_section_key(section, key):
-		return m_config.get_value(section, key)
-	print_debug(str("Non existant section/key (", section, ": ", key, ") in config file."))
-	return null
+# Dump configs into the config file. This is intended to be called just once
+# at the end of the execution.
+func write_settings_into_filesystem() -> int:
+	var config_file = load_config_file()
+	for section in m_config_map.keys():
+		for key in m_config_map.get(section).keys():
+			config_file.set_value(section, key, m_config_map.get(section).get(key))
+	return save_config_file(config_file)
 
 
-func set_setting(section, key, new_value):
-	m_config.set_value(section, key, new_value)
-	var err = m_config.save(CONFIG_FILE_PATH)
+# Save config file.
+func save_config_file(config_file: ConfigFile) -> int:
+	var err = config_file.save(CONFIG_FILE_PATH)
 	if err != OK:
 		print_debug(str("Error (", err, ") writing into config file."))
+		return FAILED
+	return OK
 
 
-func get_section_keys(section):
-	if m_config.has_section(section):
-		return m_config.get_section_keys(section)
-	print_debug(str("Non existant section (", section, ") in config file."))
+# Get config value, given a section and a key.
+func get_setting(section: String, key: String):
+	var section_settings = get_section_settings(section)
+	if section_settings != null:
+		if section_settings.has(key):
+			return section_settings.get(key)
+		print_debug(str("No such key: ", key))
+		return null
+
+
+# Get section configs.
+func get_section_settings(section: String):
+	if m_config_map.has(section):
+		return m_config_map.get(section)
+	print_debug(str("No such section: ", section))
 	return null
 
 
-# Reads the difficulty level from config file.
-func get_difficulty_from_filesystem():
-	m_game_difficulty = get_setting("game", "DIFFICULTY")
+# Set setting, given a section, a key, and a new value.
+func set_setting(section: String, key: String, value: Variant):
+	m_config_map[section][key] = value
 
 
-# Changes the current difficulty, storing its new value into the config file as well as in the
-# current game execution.
-func change_difficulty(new_difficulty: int):
-	m_game_difficulty = new_difficulty
-	set_setting("game", "DIFFICULTY", new_difficulty)
-
-
-# Difficulty getter for other scenes.
-func get_difficulty():
-	return m_game_difficulty
-
-
-# Reads the volume scales from config file.
-func get_volumes_from_filesystem():
-	m_music_volume = get_setting("sound", "VOLUME-MUSIC")
-	m_sfx_volume = get_setting("sound", "VOLUME-SFX")
-
-
-# Changes the current music volume, storing its new value into the config file as well as in the
-# current game execution.
-func change_music_volume(new_volume):
-	m_music_volume = new_volume
-	set_setting("sound", "VOLUME-MUSIC", new_volume)
-
-
-# Changes the current SFX volume, storing its new value into the config file as well as in the
-# current game execution.
-func change_sfx_volume(new_volume):
-	m_sfx_volume = new_volume
-	set_setting("sound", "VOLUME-SFX", new_volume)
-
-
-# Music volume getter for other scenes.
-func get_music_volume():
-	return m_music_volume
-
-
-# SFX volume getter for other scenes.
-func get_sfx_volume():
-	return m_sfx_volume
+# Used to handle the close request notification.
+func _notification(what):
+	if what == NOTIFICATION_WM_CLOSE_REQUEST:
+		Logger.log_infor("Writting configs into filesystem")
+		write_settings_into_filesystem()

--- a/Template/Autoloads/SfxManager.gd
+++ b/Template/Autoloads/SfxManager.gd
@@ -8,8 +8,8 @@ extends Node
 
 
 func _ready():
-	set_music_volume(GameSettings.get_music_volume())
-	set_sfx_volume(GameSettings.get_sfx_volume())
+	set_music_volume(GameSettings.get_setting("sound", "VOLUME-MUSIC"))
+	set_sfx_volume(GameSettings.get_setting("sound", "VOLUME-SFX"))
 	add_child(m_music_audio_player)
 
 
@@ -33,11 +33,11 @@ func set_music_volume(new_value):
 	# Source: https://godotengine.org/qa/40911/best-way-to-create-a-volume-slider
 	m_music_volume_db = log(new_value) * 20
 	m_music_audio_player.set_volume_db(m_music_volume_db)
-	GameSettings.change_music_volume(new_value)
+	GameSettings.set_setting("sound", "VOLUME-MUSIC", new_value)
 
 
 # Sets the SFX volume given a linear (from 0 to 1) scale.
 func set_sfx_volume(new_value):
 	# Source: https://godotengine.org/qa/40911/best-way-to-create-a-volume-slider
 	m_sfx_volume_db = log(new_value) * 20
-	GameSettings.change_sfx_volume(new_value)
+	GameSettings.set_setting("sound", "VOLUME-SFX", new_value)

--- a/Template/Credits/Credits.gd
+++ b/Template/Credits/Credits.gd
@@ -9,9 +9,14 @@ extends Node2D
 func _ready():
 	m_background.color = Settings.MENU_BACKGROUND_COLOR
 	m_credits_label.text = str(tr("CREDITS"), "\n\n")
-	for credit in GameSettings.get_section_keys("credits"):
+	for credit_key in GameSettings.get_section_settings("credits"):
 		m_credits_label.text += str(
-			tr(credit), " ", tr("BY"), " ", GameSettings.get_setting("credits", credit), "\n"
+			tr(credit_key),
+			" ",
+			tr("BY"),
+			" ",
+			GameSettings.get_setting("credits", credit_key),
+			"\n"
 		)
 
 	Logger.log_debug("Credits: Ready")

--- a/Template/Game/Game.gd
+++ b/Template/Game/Game.gd
@@ -44,4 +44,5 @@ func on_change_scene(new_scene, transition_type) -> void:
 func on_exit() -> void:
 	Logger.log_infor("Exiting game")
 
+	get_tree().root.propagate_notification(NOTIFICATION_WM_CLOSE_REQUEST)
 	get_tree().quit()

--- a/Template/OptionsMenu/OptionsMenu.gd
+++ b/Template/OptionsMenu/OptionsMenu.gd
@@ -54,7 +54,7 @@ func on_language_button_item_selected(index):
 
 # Changes the current difficulty through the GameSettings autoload.
 func on_difficulty_button_item_selected(index):
-	GameSettings.change_difficulty(index)
+	GameSettings.set_setting("game", "DIFFICULTY", index)
 
 
 func on_full_screen_button_toggled(new_full_screen):
@@ -88,10 +88,14 @@ func set_default_values():
 	else:
 		m_language_button.select(ENGLISH_INDEX)
 
-	m_difficulty_button.select(GameSettings.get_difficulty())
+	m_difficulty_button.select(GameSettings.get_setting("game", "DIFFICULTY"))
 
-	m_music_volume_slider.configure_slider(0.0001, 0.0001, 1, GameSettings.get_music_volume())
-	m_sfx_volume_slider.configure_slider(0.0001, 0.0001, 1, GameSettings.get_sfx_volume())
+	m_music_volume_slider.configure_slider(
+		0.0001, 0.0001, 1, GameSettings.get_setting("sound", "VOLUME-MUSIC")
+	)
+	m_sfx_volume_slider.configure_slider(
+		0.0001, 0.0001, 1, GameSettings.get_setting("sound", "VOLUME-SFX")
+	)
 
 
 func on_full_screen(new_full_screen):

--- a/Template/PauseMenuOptions/PauseMenuOptions.gd
+++ b/Template/PauseMenuOptions/PauseMenuOptions.gd
@@ -59,8 +59,12 @@ func set_default_values():
 		m_language_button.select(SPANISH_INDEX)
 	else:
 		m_language_button.select(ENGLISH_INDEX)
-	m_music_volume_slider.configure_slider(0.0001, 0.0001, 1, GameSettings.get_music_volume())
-	m_sfx_volume_slider.configure_slider(0.0001, 0.0001, 1, GameSettings.get_sfx_volume())
+	m_music_volume_slider.configure_slider(
+		0.0001, 0.0001, 1, GameSettings.get_setting("sound", "VOLUME-MUSIC")
+	)
+	m_sfx_volume_slider.configure_slider(
+		0.0001, 0.0001, 1, GameSettings.get_setting("sound", "VOLUME-SFX")
+	)
 
 
 func on_full_screen_button_toggled(full_screen):


### PR DESCRIPTION
| Issue |
| --- |
| Closes #64 |

## Description

Modify GameSettings autoload to load configs in memory at the start and dump them when finishing.
